### PR TITLE
stream & buffer messages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,21 @@
 *.a
 mkmf.log
 vendor/bundle
+### https://raw.github.com/github/gitignore/8edb8a95c4c4b3dce71a378aaaf89275510b9cef/Global/Vim.gitignore
+
+# Swap
+[._]*.s[a-v][a-z]
+[._]*.sw[a-p]
+[._]s[a-v][a-z]
+[._]sw[a-p]
+
+# Session
+Session.vim
+
+# Temporary
+.netrwhist
+*~
+# Auto-generated tag files
+tags
+
+

--- a/lib/ruboty/aun/actions/aun.rb
+++ b/lib/ruboty/aun/actions/aun.rb
@@ -10,9 +10,19 @@ module Ruboty
               stdin.puts message.body
               stdin.close
 
+              t = Time.now
+              text = ""
               while line = stdout_err.gets
-                message.reply(line)
+                elapsed = Time.now - t 
+
+                if elapsed > 1
+                  message.reply(truncate_text(text))
+                  t = Time.now
+                  text = ""
+                end
+                text << line
               end
+              message.reply(truncate_text(text)) unless text.nil?
             
               exit_status = wait_thr.value
               unless exit_status.success?
@@ -26,6 +36,10 @@ module Ruboty
 
         def handlers
           Dir['aun/**/*'].select {|handler| File.executable?(handler) }
+        end
+
+        def truncate_text(text)
+          text.size > 3900 ? text[0..3900].chomp + "..........(`truncated`)\n" : text
         end
       end
     end

--- a/lib/ruboty/aun/actions/aun.rb
+++ b/lib/ruboty/aun/actions/aun.rb
@@ -6,7 +6,7 @@ module Ruboty
       class Aun < Ruboty::Actions::Base
         def call
           handlers.each do |handler|
-            Open3.popen2e(handler, stdin_data: message.body) do |stdin, stdout_err, wait_thr|
+            Open3.popen2e(handler) do |message.body, stdout_err, wait_thr|
               while line = stdout_err.gets
                 message.reply(stdout_err)
               end

--- a/lib/ruboty/aun/actions/aun.rb
+++ b/lib/ruboty/aun/actions/aun.rb
@@ -6,7 +6,10 @@ module Ruboty
       class Aun < Ruboty::Actions::Base
         def call
           handlers.each do |handler|
-            Open3.popen2e(handler) do |message.body, stdout_err, wait_thr|
+            Open3.popen2e(handler) do |stdin, stdout_err, wait_thr|
+              stdin.puts message.body
+              stdin.close
+
               while line = stdout_err.gets
                 message.reply(stdout_err)
               end

--- a/lib/ruboty/aun/actions/aun.rb
+++ b/lib/ruboty/aun/actions/aun.rb
@@ -11,7 +11,7 @@ module Ruboty
               stdin.close
 
               while line = stdout_err.gets
-                message.reply(stdout_err)
+                message.reply(line)
               end
             
               exit_status = wait_thr.value

--- a/lib/ruboty/aun/version.rb
+++ b/lib/ruboty/aun/version.rb
@@ -1,5 +1,5 @@
 module Ruboty
   module Aun
-    VERSION = "1.1.2"
+    VERSION = "1.1.3"
   end
 end

--- a/lib/ruboty/aun/version.rb
+++ b/lib/ruboty/aun/version.rb
@@ -1,5 +1,5 @@
 module Ruboty
   module Aun
-    VERSION = "1.0.0"
+    VERSION = "1.1.0"
   end
 end

--- a/lib/ruboty/aun/version.rb
+++ b/lib/ruboty/aun/version.rb
@@ -1,5 +1,5 @@
 module Ruboty
   module Aun
-    VERSION = "1.1.3"
+    VERSION = "1.2.0"
   end
 end

--- a/lib/ruboty/aun/version.rb
+++ b/lib/ruboty/aun/version.rb
@@ -1,5 +1,5 @@
 module Ruboty
   module Aun
-    VERSION = "1.1.0"
+    VERSION = "1.1.1"
   end
 end

--- a/lib/ruboty/aun/version.rb
+++ b/lib/ruboty/aun/version.rb
@@ -1,5 +1,5 @@
 module Ruboty
   module Aun
-    VERSION = "1.1.1"
+    VERSION = "1.1.2"
   end
 end


### PR DESCRIPTION
Optimized for Slack API

- Stream messages
- Buffer messages
  - limit message size < 4000 characters
  - limit call to 1req/s
- add `.gitignore`

ref:
https://api.slack.com/rtm#limits
https://api.slack.com/docs/rate-limits